### PR TITLE
network: bridge: create fakedev in mounted directory

### DIFF
--- a/pkg/network/bridge/plugin.go
+++ b/pkg/network/bridge/plugin.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	resourceNamespace   = "bridge.network.kubevirt.io/"
-	fakeDevicePath      = "/tmp/deviceplugin-network-bridge-fakedev"
+	fakeDevicePath      = "/var/run/device-plugin-network-bridge-fakedev"
 	interfaceNameLen    = 15
 	interfaceNamePrefix = "nic_"
 	letterBytes         = "abcdefghijklmnopqrstuvwxyz0123456789"


### PR DESCRIPTION
Bridge device plugin creates fake device that is mounted to containers
requesting bridge resource. In case device plugin is running in a pod,
this fake device is created inside its file-system and therefore it is
not visible for host system. With this change, we create fake device
in mounted /var/run directory.
