### PR TITLE
network: bridge: raise bridge assignment timeout

### DIFF
--- a/pkg/network/bridge/plugin.go
+++ b/pkg/network/bridge/plugin.go
@@ -22,7 +22,7 @@ const (
 	interfaceNameLen    = 15
 	interfaceNamePrefix = "nic_"
 	letterBytes         = "abcdefghijklmnopqrstuvwxyz0123456789"
-	assignmentTimeout   = 5 * time.Minute
+	assignmentTimeout   = 30 * time.Minute
 )
 
 type NetworkBridgeDevicePlugin struct {


### PR DESCRIPTION
Current 5 minute timeout is too low in case pod's scheduling was
postponed (e.g. resource was not available).