### PR TITLE
kvm: Add DaemonSet example

### DIFF
--- a/cmd/kvm/Dockerfile
+++ b/cmd/kvm/Dockerfile
@@ -2,4 +2,4 @@ FROM fedora:27
 
 COPY kvm /kvm
 
-CMD ["/kvm"]
+ENTRYPOINT ["/kvm"]

--- a/docs/kvm/README.md
+++ b/docs/kvm/README.md
@@ -33,13 +33,20 @@ sudo ./kvm -v 3 -logtostderr
 
 ### Docker
 ```
-docker run -it -v /dev:/dev -v /sys:/sys -v /lib/modules:/lib/modules -v /var/lib/kubelet/device-plugins:/var/lib/kubelet/device-plugins --privileged --cap-add=ALL kvm:latest /bin/bash
+docker run -it -v /var/lib/kubelet/device-plugins:/var/lib/kubelet/device-plugins --privileged --cap-add=ALL kvm:latest /bin/bash
 (in docker image) ./kvm -v 3 -logtostderr
 ```
 
 ## As a DaemonSet
 
-NOTE: This process is not finalized yet.
+```
+# Deploy the device plugin
+kubectl apply -f manifests/kvm-ds.yml
+
+# Optionally you can now test it using an example consumer
+kubectl apply -f docs/kvm/consumer.yml
+kubectl exec -it kvm-consumer -- ls /dev/kvm
+```
 
 ## API
 
@@ -48,7 +55,7 @@ Node description:
 ```yaml
 Capacity:
  ...
- devices.kubevirt.io/kvm:  3
+ devices.kubevirt.io/kvm: "3"
  ...
 ```
 
@@ -61,9 +68,9 @@ spec:
     ...
     resources:
       requests:
-              devices.kubevirt.io/kvm: 1
+              devices.kubevirt.io/kvm: "1"
       limits:
-              devices.kubevirt.io/kvm: 1
+              devices.kubevirt.io/kvm: "1"
 ```
 
 ## Issues

--- a/docs/kvm/consumer-pod.yml
+++ b/docs/kvm/consumer-pod.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kvm-consumer
+spec:
+  containers:
+  - name: busybox
+    image: busybox
+    command: ["/bin/sleep", "123"]
+    resources:
+      limits:
+        devices.kubevirt.io/kvm: 1

--- a/manifests/kvm-ds.yml
+++ b/manifests/kvm-ds.yml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    name: device-plugin-kvm
+  name: device-plugin-kvm
+spec:
+  selector:
+    matchLabels:
+      name: device-plugin-kvm
+  template:
+    metadata:
+      labels:
+        name: device-plugin-kvm
+    spec:
+      containers:
+      - name: device-plugin-kvm
+        image: quay.io/kubevirt/device-plugin-kvm
+        args: ["-v3", "-logtostderr"]
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: device-plugin
+            mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins


### PR DESCRIPTION
The daemonset can be used to deploy the kvm device-plugin on all nodes of a cluster.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>