### PR TITLE
Run functional tests on STDCI

### DIFF
--- a/automation/check-patch.mounts
+++ b/automation/check-patch.mounts
@@ -1,0 +1,1 @@
+/var/run/docker.sock:/var/run/docker.sock

--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -1,0 +1,5 @@
+docker
+git
+python-pip
+python-devel
+golang-1.9.4

--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -xe
+
+install_deps() {
+    pip install pytest
+}
+
+main() {
+    echo "TODO: Add functional tests"
+}
+
+[[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/stdci.yaml
+++ b/stdci.yaml
@@ -1,0 +1,7 @@
+runtime_requirements:
+  support_nesting_level: 2
+  isolation_level: container
+
+reporting:
+  style: stdci
+


### PR DESCRIPTION
Run check-patch.sh in STDCI on each PR.
check-patch.sh will create a cluster and run the functional tests.
stdci.yaml indicates that the automation should run on a bare-metal
server.

Signed-off-by: gbenhaim <galbh2@gmail.com>