### PR TITLE
Add fuse mount support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ handling for common patterns.
 
 Each plugin may have it's own build instructions in the linked README.md.
 
-* [VFIO](docs/README.vfio.md)
+* [FUSE](docs/README.fuse.md)
 * [KVM](docs/README.kvm.md)
 * Network
   * [Bridge](docs/README.bridge.md)
+* [VFIO](docs/README.vfio.md)
 
 ## Creating Device Plugin
 

--- a/cmd/fuse/fuse.go
+++ b/cmd/fuse/fuse.go
@@ -1,0 +1,16 @@
+// License MIT
+package main
+
+import (
+	"flag"
+
+	"github.com/kubevirt/device-plugin-manager/pkg/dpm"
+	"github.com/kubevirt/kubernetes-device-plugins/pkg/fuse"
+)
+
+func main() {
+	flag.Parse()
+
+	manager := dpm.NewManager(fuse.FuseLister{})
+	manager.Run()
+}

--- a/docs/README.fuse.md
+++ b/docs/README.fuse.md
@@ -69,8 +69,7 @@ spec:
               devices.kubevirt.io/fuse: "1"
 ```
 
-The device does not need a priviliged container to use it, but it does require the `mount` system call and CAP_SETUID. The `mount` system call can be made
-available by a seccomp profile.
+The device does not need a priviliged container to use it, but it does require the `mount` system call and CAP_SETUID. The `mount` and `umount` system calls can be made available by a [security context (seccomp) profile](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
 ## Issues
 

--- a/docs/README.fuse.md
+++ b/docs/README.fuse.md
@@ -1,0 +1,84 @@
+# FUSE Device Plugin
+
+## Introduction
+
+This software is a kubernetes [device plugin](https://kubernetes.io/docs/concepts/cluster-administration/device-plugins/) that exposes /dev/fuse from the system.
+
+## Building
+
+NOTE: This process is not finalized yet.
+
+### Plain binary
+
+```bash
+cd cmd/fuse
+go build .
+```
+
+### Docker
+
+```bash
+docker build -t fuse:latest .
+```
+
+## Running
+
+NOTE: This process is not finalized yet.
+
+### Locally
+```bash
+cd cmd/fuse
+sudo ./fuse -v 3 -logtostderr
+```
+
+### Docker
+```
+docker run -it -v /var/lib/kubelet/device-plugins:/var/lib/kubelet/device-plugins --privileged --cap-add=ALL fuse:latest /bin/bash
+(in docker image) ./fuse -v 3 -logtostderr
+```
+
+## As a DaemonSet
+
+```
+# Deploy the device plugin
+kubectl apply -f manifests/fuse-ds.yml
+```
+
+## API
+
+Node description:
+
+```yaml
+Capacity:
+ ...
+ devices.kubevirt.io/fuse: "3"
+ ...
+```
+
+Pod:
+
+```yaml
+spec:
+  containers:
+  - name: demo
+    ...
+    resources:
+      requests:
+              devices.kubevirt.io/fuse: "1"
+      limits:
+              devices.kubevirt.io/fuse: "1"
+```
+
+The device does not need a priviliged container to use it, but it does require the `mount` system call and CAP_SETUID. The `mount` system call can be made
+available by a seccomp profile.
+
+## Issues
+
+### FUSE Quantity
+
+Currently, Kubernetes device plugins can only expose quantifiable resources.
+FUSE itself is "infinite" resource, so it cannot be properly expressed.
+
+This fact is worked around by the plugin: it adds one more FUSE resource each
+time VM is started. Because we have no way of detecting stopped VMs, the FUSE
+counter never goes down -- that causes the plugin to consume excessive memory.

--- a/manifests/fuse-ds.yaml
+++ b/manifests/fuse-ds.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    name: device-plugin-fuse
+  name: device-plugin-fuse
+spec:
+  selector:
+    matchLabels:
+      name: device-plugin-fuse
+  template:
+    metadata:
+      labels:
+        name: device-plugin-fuse
+    spec:
+      containers:
+      - name: device-plugin-fuse
+        image: quay.io/kubevirt/device-plugin-fuse
+        args: ["-v", "3", "-logtostderr"]
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: device-plugin
+            mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -76,7 +76,7 @@ func (p *FusePlugin) Allocate(ctx context.Context, request *pluginapi.AllocateRe
 	var car pluginapi.ContainerAllocateResponse
 	var dev *pluginapi.DeviceSpec
 
-	glog.V(3).Infof("Allocated virtual fuse device %d", p.counter)
+	glog.V(3).Infof("Allocated virtual fuse device %d (requested id: %s)", p.counter, request.ContainerRequests[0].DevicesIDs[0])
 	p.counter += 1
 
 	car = pluginapi.ContainerAllocateResponse{}

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -8,6 +8,7 @@ import (
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
 	"fmt"
 	"time"
+	"os/exec"
 )
 
 const (
@@ -45,6 +46,15 @@ func (FuseLister) NewPlugin(deviceID string) dpm.PluginInterface {
 	glog.V(3).Infof("Creating device plugin %s", deviceID)
 
 	return &FusePlugin{}
+}
+
+// Ensure the fuse module is loaded
+func (p *FusePlugin) Start() error {
+	glog.V(3).Infof("Ensuring fuse kernel module is loaded")
+	cmd := exec.Command("modprobe", "fuse")
+	err := cmd.Run()
+
+	return err
 }
 
 func (p *FusePlugin) ListAndWatch(e *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -31,7 +31,7 @@ func (l FuseLister) GetResourceNamespace() string {
 	return Namespace
 }
 
-// Discovery discovers all FUSE devices within the system.
+// Discovery discovers the FUSE device within the system.
 func (l FuseLister) Discover(pluginListCh chan dpm.PluginNameList) {
 	var plugins = make(dpm.PluginNameList, 0)
 

--- a/pkg/fuse/fuse.go
+++ b/pkg/fuse/fuse.go
@@ -1,0 +1,113 @@
+package fuse
+
+import (
+	"os"
+	"strconv"
+
+	"context"
+	"github.com/golang/glog"
+	"github.com/kubevirt/device-plugin-manager/pkg/dpm"
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
+)
+
+const (
+	FUSEPath  = "/dev/fuse"
+	FUSEName  = "fuse"
+	Namespace = "devices.kubevirt.io"
+)
+
+type message struct{}
+
+type FusePlugin struct {
+	counter int
+	devs    []*pluginapi.Device
+	update  chan message
+}
+
+// object responsible for discovering initial pool of devices and their allocation.
+type FuseLister struct{}
+
+func (l FuseLister) GetResourceNamespace() string {
+	return Namespace
+}
+
+// Discovery discovers all FUSE devices within the system.
+func (l FuseLister) Discover(pluginListCh chan dpm.PluginNameList) {
+	var plugins = make(dpm.PluginNameList, 0)
+
+	if _, err := os.Stat(FUSEPath); err == nil {
+		glog.V(3).Infof("Discovered %s", FUSEPath)
+		plugins = append(plugins, FUSEName)
+	}
+	pluginListCh <- plugins
+}
+
+func (FuseLister) NewPlugin(deviceID string) dpm.PluginInterface {
+	glog.V(3).Infof("Creating device plugin %s", deviceID)
+
+	return &FusePlugin{
+		counter: 0,
+		devs:    make([]*pluginapi.Device, 0),
+		update:  make(chan message),
+	}
+}
+
+func (p *FusePlugin) ListAndWatch(e *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
+	// initialize with one available device
+	p.devs = append(p.devs, &pluginapi.Device{
+		ID:	FUSEName + strconv.Itoa(p.counter),
+		Health: pluginapi.Healthy,
+	})
+
+	glog.V(3).Infof("Returning %d available devices", len(p.devs))
+
+	s.Send(&pluginapi.ListAndWatchResponse{Devices: p.devs})
+
+	for {
+		select {
+		case <-p.update:
+			s.Send(&pluginapi.ListAndWatchResponse{Devices: p.devs})
+		}
+	}
+}
+
+func (p *FusePlugin) Allocate(ctx context.Context, request *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
+	var response pluginapi.AllocateResponse
+	var car pluginapi.ContainerAllocateResponse
+	var dev *pluginapi.DeviceSpec
+
+	p.devs = append(p.devs, &pluginapi.Device{
+		ID:     FUSEPath + strconv.Itoa(p.counter),
+		Health: pluginapi.Healthy,
+	})
+
+	glog.V(3).Infof("Allocated virtual fuse device %d", p.counter)
+
+	p.counter += 1
+	p.update <- message{}
+
+	car = pluginapi.ContainerAllocateResponse{}
+
+	dev = new(pluginapi.DeviceSpec)
+	dev.HostPath = FUSEPath
+	dev.ContainerPath = FUSEPath
+	dev.Permissions = "rw"
+	car.Devices = append(car.Devices, dev)
+
+	response.ContainerResponses = append(response.ContainerResponses, &car)
+
+	return &response, nil
+}
+
+// GetDevicePluginOptions returns options to be communicated with Device
+// Manager
+func (p *FusePlugin) GetDevicePluginOptions(context.Context, *pluginapi.Empty) (*pluginapi.DevicePluginOptions, error) {
+	return nil, nil
+}
+
+// PreStartContainer is called, if indicated by Device Plugin during registration phase,
+// before each container start. Device plugin can run device specific operations
+// such as resetting the device before making devices available to the container
+func (p *FusePlugin) PreStartContainer(context.Context, *pluginapi.PreStartContainerRequest) (*pluginapi.PreStartContainerResponse, error) {
+	return nil, nil
+}


### PR DESCRIPTION
This add support for /dev/fuse which allows users to mount fuse file systems. "mount" syscall support is required (seccomp)