### PR TITLE
Fix compile error: "Info call has possible formatting directive %s"

### DIFF
--- a/pkg/network/bridge/plugin.go
+++ b/pkg/network/bridge/plugin.go
@@ -155,7 +155,7 @@ func (nbdp *NetworkBridgeDevicePlugin) Allocate(ctx context.Context, r *pluginap
 		envVarName := fmt.Sprintf("%s%s", envVarNamePrefix, strings.ToUpper(randString(envVarNameSuffixLen)))
 		marshalled, err := json.Marshal(vnicsPerInterface)
 		if err != nil {
-			glog.V(3).Info("Failed to marshal network interface description due to: %s", err.Error())
+			glog.V(3).Infof("Failed to marshal network interface description due to: %s", err.Error())
 			continue
 		}
 
@@ -211,7 +211,7 @@ func (nbdp *NetworkBridgeDevicePlugin) attachPods() {
 
 					containerPid, err := cli.GetPidByContainerID(containerID)
 					if err != nil {
-						glog.V(3).Info("Failed to obtain container's pid, due to: %s", err.Error())
+						glog.V(3).Infof("Failed to obtain container's pid, due to: %s", err.Error())
 						return false
 					}
 


### PR DESCRIPTION
Current master checkout doesn't compile with go 1.13:

```
nickb@nickb-laptop:~/go/src/github.com/kubevirt/kubernetes-device-plugins$ make
go fmt ./pkg/...
go vet ./pkg/...
# github.com/kubevirt/kubernetes-device-plugins/pkg/network/bridge
pkg/network/bridge/plugin.go:158:4: Info call has possible formatting directive %s
pkg/network/bridge/plugin.go:214:7: Info call has possible formatting directive %s
make: *** [Makefile:24: format] Error 2

```